### PR TITLE
backup sshd_config before edits

### DIFF
--- a/modules/base/base.sh
+++ b/modules/base/base.sh
@@ -10,6 +10,7 @@ run_base() {
   fi
 
   if [[ -f /etc/ssh/sshd_config ]]; then
+    backup_file /etc/ssh/sshd_config
     sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config || true
     sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config || true
     systemctl reload ssh || systemctl reload sshd || true

--- a/tests/modules_base.bats
+++ b/tests/modules_base.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() { cd "$BATS_TEST_DIRNAME/.."; }
+
+teardown() {
+  rm -f /etc/ssh/sshd_config /etc/ssh/sshd_config.bak.mona.*
+}
+
+@test "run_base does not overwrite sshd_config backup" {
+  echo 'PasswordAuthentication yes' >/etc/ssh/sshd_config
+  rm -f /etc/ssh/sshd_config.bak.mona.*
+
+  for cmd in timedatectl systemctl ufw; do
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$BATS_TEST_TMPDIR/$cmd"
+    chmod +x "$BATS_TEST_TMPDIR/$cmd"
+  done
+
+  run bash -lc "export PATH='$BATS_TEST_TMPDIR':\$PATH; export MONA_DIR=$(pwd); . modules/base/base.sh; run_base"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[mona] backup:"* ]]
+  first_backup=$(ls /etc/ssh/sshd_config.bak.mona.*)
+
+  sleep 1
+
+  run bash -lc "export PATH='$BATS_TEST_TMPDIR':\$PATH; export MONA_DIR=$(pwd); . modules/base/base.sh; run_base"
+  [ "$status" -eq 0 ]
+  backups=(/etc/ssh/sshd_config.bak.mona.*)
+  [ -f "$first_backup" ]
+  [ "${#backups[@]}" -eq 2 ]
+}


### PR DESCRIPTION
## Summary
- back up `/etc/ssh/sshd_config` before hardening ssh options
- test that `run_base` keeps existing backup when rerun

## Testing
- `pre-commit run --files modules/base/base.sh tests/modules_base.bats`
- `bats -r tests`


------
https://chatgpt.com/codex/tasks/task_e_68b42662c7f88322a3062bfb853f093f