### PR TITLE
chore: run ec optionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,9 @@ fmt:
 lint:
 	bash -O globstar -c 'shellcheck -x bin/mona modules/**/*.sh'
 	shfmt -d bin modules recipes tests
-	ec
+	if command -v ec >/dev/null 2>&1; then ec; else echo "Install editorconfig-checker (ec) for EditorConfig validation: pip install editorconfig-checker"; fi
 
 test:
 	bats -r tests
 
 ci: lint test
-

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ sudo ./bin/mona
 
 ## Install
 
-Clone the repo and install dev deps:
+Clone the repo and install dev deps (ShellCheck, shfmt, BATS, optional editorconfig-checker):
 
 ```bash
 git clone https://github.com/Monynha-Softwares/MonaRepoTui.git
 cd MonaRepoTui
 make install-dev
 ```
+
+`make install-dev` includes the [EditorConfig Checker](https://github.com/editorconfig-checker/editorconfig-checker) (`ec`) for optional EditorConfig validation. If it's missing, `make lint` will remind you to install it.
 
 ### TUI dependency
 


### PR DESCRIPTION
## Summary
- run editorconfig-checker only if `ec` is installed and warn when missing
- document editorconfig-checker as an optional dev dependency

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b429c437bc83229a499bb360264719