### PR TITLE
Warn about missing bashsimplecurses submodule

### DIFF
--- a/bin/mona
+++ b/bin/mona
@@ -60,7 +60,10 @@ mkdir -p "$MONA_TMP_DIR"
 # -------------------------- bashsimplecurses --------------------------------
 SIMPLE_CURSES="${MONA_DIR}/ui/bashsimplecurses/simple_curses.sh"
 fetch_simple_curses() {
-  warn "bashsimplecurses não encontrado; tentando baixar (curl)…"
+  warn "bashsimplecurses não encontrado."
+  warn "  git submodule add https://github.com/metal3d/bashsimplecurses ui/bashsimplecurses"
+  warn "  git submodule update --init --recursive"
+  warn "Tentando baixar (curl)…"
   local dst_dir="${MONA_DIR}/ui/bashsimplecurses"
   mkdir -p "$dst_dir"
   if command -v curl >/dev/null 2>&1; then

--- a/tests/simple_curses.bats
+++ b/tests/simple_curses.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "warns about missing bashsimplecurses" {
+  local sc="ui/bashsimplecurses/simple_curses.sh"
+  rm -f "$sc"
+  run env MONA_NONINTERACTIVE=1 ./bin/mona
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git submodule add https://github.com/metal3d/bashsimplecurses ui/bashsimplecurses"* ]]
+  [[ "$output" == *"git submodule update --init --recursive"* ]]
+  rm -f "$sc"
+}


### PR DESCRIPTION
## Summary
- advise users to add `bashsimplecurses` as a git submodule when it's missing
- ensure warning appears during noninteractive runs and cover with BATS test

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b42bc610908322a51ac5fa408fb75d