### PR TITLE
Add version consistency test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ make install-dev
 * Format: `make fmt`
 * Lint: `make lint`
 * Test: `make test`
+* Version bumps: update the version in `README.md` and keep `tests/version.bats` in sync with `./bin/mona --version`.
 
 Please run the above before submitting a PR.
 

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+@test "README version matches mona --version" {
+  readme_version=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -n1 | sed 's/^v//')
+  run env MONA_NONINTERACTIVE=1 ./bin/mona --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "$readme_version" ]
+}


### PR DESCRIPTION
## Summary
- add BATS test comparing `./bin/mona --version` with README version string
- document that test must be kept in sync on version bumps

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b42f957bfc8322a25ed177e9e76eda